### PR TITLE
Fix syntax of string format repr converters.

### DIFF
--- a/tinycss2/ast.py
+++ b/tinycss2/ast.py
@@ -132,7 +132,7 @@ class Comment(Node):
     """
     __slots__ = ['value']
     type = 'comment'
-    repr_format = '<{self.__class__.__name__} {self.value:r}>'
+    repr_format = '<{self.__class__.__name__} {self.value!r}>'
 
     def __init__(self, line, column, value):
         Node.__init__(self, line, column)
@@ -319,7 +319,7 @@ class StringToken(Node):
     """
     __slots__ = ['value']
     type = 'string'
-    repr_format = '<{self.__class__.__name__} {self.value:r}>'
+    repr_format = '<{self.__class__.__name__} {self.value!r}>'
 
     def __init__(self, line, column, value):
         Node.__init__(self, line, column)


### PR DESCRIPTION
There's an error while `repr`-ing String or Comment nodes:

```
  File "tinycss2/ast.py", line 61, in __repr__
    return self.repr_format.format(self=self)
ValueError: Unknown format code 'r' for object of type 'unicode'
```

According to the [format string syntax](https://docs.python.org/3/library/string.html#format-string-syntax) "r" is a converter not a format spec.  
