### PR TITLE
Fix UTF-8 decoding for tests on Python 3.6.

### DIFF
--- a/tinycss2/test.py
+++ b/tinycss2/test.py
@@ -4,6 +4,7 @@ import functools
 import json
 import os.path
 import pprint
+from io import open
 
 import pytest
 from webencodings import Encoding, lookup
@@ -79,7 +80,8 @@ def to_json():
 
 def load_json(filename):
     json_data = json.load(open(os.path.join(
-        os.path.dirname(__file__), 'css-parsing-tests', filename)))
+        os.path.dirname(__file__), 'css-parsing-tests', filename),
+        encoding='utf-8'))
     return list(zip(json_data[::2], json_data[1::2]))
 
 


### PR DESCRIPTION
Tests have failed when decoding JSON files during test runs with Python 3.6
because no encoding was specified when opening the files.

This patch enforces UTF-8 when decoding JSON files by using the `open` method
from the `io` package.