### PR TITLE
Add testing for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       python: 3.6
     - dist: xenial
       python: 3.7
+    - python: 3.8
     - os: linux
       python: pypy3
     - os: osx

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
   Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
   Topic :: Text Processing
 project_urls =
   Documentation = https://tinycss2.readthedocs.io/


### PR DESCRIPTION
Python 3.8 was released on October 14th, 2019.