### PR TITLE
Python 3 only cleanups

### DIFF
--- a/tinycss2/ast.py
+++ b/tinycss2/ast.py
@@ -4,14 +4,13 @@ Data structures for the CSS abstract syntax tree.
 
 """
 
-from __future__ import unicode_literals
 
 from webencodings import ascii_lower
 
 from .serializer import _serialize_to, serialize_identifier, serialize_name
 
 
-class Node(object):
+class Node:
     """Every node type inherits from this class,
     which is never instantiated directly.
 

--- a/tinycss2/color3.py
+++ b/tinycss2/color3.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import collections
 import re
 

--- a/tinycss2/css-parsing-tests/make_color3_keywords.py
+++ b/tinycss2/css-parsing-tests/make_color3_keywords.py
@@ -185,7 +185,7 @@ print(',\n'.join(
         (replace(keyword, i, lambda c: r'\\%X ' % ord(c)), True, True),
         (replace(keyword, i, lambda c: ''), False, True),
         # Kelving sign: u'K'.lower() == u'k', but should not match in CSS
-        (keyword.replace('k', u'K'), False, 'k' in keyword)
+        (keyword.replace('k', 'K'), False, 'k' in keyword)
     ]
     if run
 ))

--- a/tinycss2/serializer.py
+++ b/tinycss2/serializer.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-
-
 def serialize(nodes):
     """Serialize nodes to CSS syntax.
 

--- a/tinycss2/tokenizer.py
+++ b/tinycss2/tokenizer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import re
 import sys
 


### PR DESCRIPTION
As the project is Python 3 only, can do a few cleanups:

- Remove `__future__` imports
- Remove u prefix from strings
- Remove inheritance from object

All of the above are defaults in Python 3.