### PR TITLE
Fix ResourceWarning due to unclosed file in test_tinycss2.py

### DIFF
--- a/tinycss2/test_tinycss2.py
+++ b/tinycss2/test_tinycss2.py
@@ -20,6 +20,8 @@ from .ast import (AtKeywordToken, AtRule, Comment, CurlyBracketsBlock,
 from .color3 import RGBA, parse_color
 from .nth import parse_nth
 
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'css-parsing-tests')
+
 
 def generic(func):
     implementations = func()
@@ -77,9 +79,9 @@ def to_json():
 
 
 def load_json(filename):
-    json_data = json.load(open(os.path.join(
-        os.path.dirname(__file__), 'css-parsing-tests', filename),
-        encoding='utf-8'))
+    path = os.path.join(DATA_DIR, filename)
+    with open(path, encoding='utf-8') as fp:
+        json_data = json.load(fp)
     return list(zip(json_data[::2], json_data[1::2]))
 
 


### PR DESCRIPTION
Running the tests with warnings would previously result in the warning emitted:

    tinycss2/test_tinycss2.py:80
      .../tinycss2/tinycss2/test_tinycss2.py:80: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/jon/devel/tinycss2/tinycss2/css-parsing-tests/color3.json' mode='r' encoding='utf-8'>
        json_data = json.load(open(os.path.join(

To solve, open and close the file with a context manager. The directory
to the data is now calculated and cached once rather than in each call
of load_json().