### PR TITLE
Add additional trove classifiers to more explicitly specify support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,11 +20,15 @@ classifiers =
   Development Status :: 5 - Production/Stable
   Intended Audience :: Developers
   License :: OSI Approved :: BSD License
+  Programming Language :: Python
   Programming Language :: Python :: 3
+  Programming Language :: Python :: 3 :: Only
   Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
+  Programming Language :: Python :: Implementation :: CPython
+  Programming Language :: Python :: Implementation :: PyPy
   Topic :: Text Processing
 project_urls =
   Documentation = https://tinycss2.readthedocs.io/


### PR DESCRIPTION
- The project is Python 3 only.
- The project support PyPy (and of course CPython).