### PR TITLE
Add tox.ini to allowing running the full test matrix locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 sudo: false
 
+env:
+  global:
+    - TOXENV=py
+
 matrix:
   include:
     - python: 3.5
@@ -12,8 +16,7 @@ matrix:
       language: generic
 
 install:
-  - pip3 install --upgrade setuptools
-  - pip3 install --upgrade -e.[test]
+  - pip3 install tox
 
 script:
-  - python3 setup.py test
+  - tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,15 +34,9 @@ project_urls =
 
 [options]
 packages = find:
-setup_requires = pytest-runner
 install_requires =
   setuptools >= 39.2.0
   webencodings >= 0.4
-tests_require =
-  pytest-runner
-  pytest-cov
-  pytest-flake8
-  pytest-isort
 python_requires = >= 3.5
 
 [options.package_data]
@@ -55,7 +49,6 @@ doc =
   sphinx
   sphinx_rtd_theme
 test =
-  pytest-runner
   pytest-cov
   pytest-flake8
   pytest-isort
@@ -66,9 +59,6 @@ python-tag = py3
 [build_sphinx]
 source-dir = docs
 build-dir = docs/_build
-
-[aliases]
-test = pytest
 
 [tool:pytest]
 addopts = --flake8 --isort

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py{35,36,37,38,py3}
+minversion = 2.4
+
+[testenv]
+commands = {envpython} -m pytest {posargs}
+extras = test


### PR DESCRIPTION
To run the full test matrix, a contributor can now simply use the
command:

    $ tox

This will run all supported Python versions including PyPy. It finishes
with:

    py35: commands succeeded
    py36: commands succeeded
    py37: commands succeeded
    py38: commands succeeded
    pypy3: commands succeeded
    congratulations :)

Travis now uses tox as the test entrypoint so tests continue run the
same locally and on Travis.

This replaces the deprecated command 'python setup.py test'. This was
deprecated in setuptools v41.5.0 (27 Oct 2019) and will be removed in a
future version. The tests_require option is also deprecated.

As setuptools_required was only being used to run tests, it has also
been cleaned up.