### PR TITLE
Remove deprecated license_file from setup.cfg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ name = tinycss2
 url = https://tinycss2.readthedocs.io/
 version = file: tinycss2/VERSION
 license = BSD
-license_file = LICENSE
 description = Low-level CSS parser for Python
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
Starting with wheel 0.32.0 (2018-09-29), the "license_file" option is
deprecated.

The wheel will continue to include LICENSE, it is now included
automatically:

https://wheel.readthedocs.io/en/stable/news.html
https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file