### PR TITLE
Replace use of deprecated 'setup.py test' with pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - pip3 install --upgrade -e.[test]
 
 script:
-  - python3 setup.py test
+  - pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,15 +34,9 @@ project_urls =
 
 [options]
 packages = find:
-setup_requires = pytest-runner
 install_requires =
   setuptools >= 39.2.0
   webencodings >= 0.4
-tests_require =
-  pytest-runner
-  pytest-cov
-  pytest-flake8
-  pytest-isort
 python_requires = >= 3.5
 
 [options.package_data]
@@ -55,7 +49,7 @@ doc =
   sphinx
   sphinx_rtd_theme
 test =
-  pytest-runner
+  pytest
   pytest-cov
   pytest-flake8
   pytest-isort
@@ -66,9 +60,6 @@ python-tag = py3
 [build_sphinx]
 source-dir = docs
 build-dir = docs/_build
-
-[aliases]
-test = pytest
 
 [tool:pytest]
 addopts = --flake8 --isort


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command is formally
deprecated and should not be used. Now, run the pytest command directly
as recommended by setuptools.