### PR TITLE
Fixed Function AST serialization for nested functions with no arguments

### DIFF
--- a/tests/test_tinycss2.py
+++ b/tests/test_tinycss2.py
@@ -217,6 +217,19 @@ def test_serialize_declarations():
     assert serialize(rules) == source
 
 
+def test_serialize_rules_with_functions():
+    source = '''
+        foo#bar.baz {
+            background: url();
+            color: rgb(0, 0, 0);
+            width: calc(calc());
+            height: calc(calc(calc()));
+        }
+    '''
+    rules = parse_rule_list(source)
+    assert serialize(rules) == source
+
+
 def test_backslash_delim():
     source = '\\\nfoo'
     tokens = parse_component_value_list(source)

--- a/tinycss2/ast.py
+++ b/tinycss2/ast.py
@@ -694,15 +694,14 @@ class FunctionBlock(Node):
         write(serialize_identifier(self.name))
         write('(')
         _serialize_to(self.arguments, write)
-        if self.arguments:
-            function = self
-            while isinstance(function, FunctionBlock):
-                eof_in_string = (
-                    isinstance(function.arguments[-1], ParseError) and
-                    function.arguments[-1].kind == 'eof-in-string')
-                if eof_in_string:
-                    return
-                function = function.arguments[-1]
+        function = self
+        while isinstance(function, FunctionBlock) and function.arguments:
+            eof_in_string = (
+                isinstance(function.arguments[-1], ParseError) and
+                function.arguments[-1].kind == 'eof-in-string')
+            if eof_in_string:
+                return
+            function = function.arguments[-1]
         write(')')
 
 


### PR DESCRIPTION
Hello @liZe, thanks for your work so far!

I'm using this package for parsing and the code will sometimes receive CSS function calls with no arguments. What I found was, in these cases the parser succeeds, creating a FunctionBlock as usual (no ParseError), but its arguments will remain empty. When serializing the nodes, it fails with `IndexError`, because it tries to access an argument.

The serialization logic does indeed have a sanity check for the args not to be empty, however, that's only for the top-level function call - after it begins recursively accessing the nested calls, it no longer applies this check.

This PR simply moves the check to be applicable to all levels of nesting, so that the serializer doesn't outright fail with an exception.

--

Now, thing is, I think that theoretically in CSS you can't have functions with no arguments, according to the spec and all vendor implementations. In practice, however, people sometimes do that for various reasons (mistakes, esoteric IE compact tricks, etc.) - so this fix would especially be useful for parsing dynamic content (out of the dev's control).

Given this, if you think it's more correct, I guess we also have the alternative to "fix" this at the parser level, by replacing any functions with no argument with a `ParseError`.

Whatever the approach, I think what's important is stopping it from raising `IndexError` and thus failing the entire serialization process.

Also, let me know if you want to add a test case for this specific situation - in which case I think you're using a separate repo for seeding the scenarios?

Thanks!