### PR TITLE
Distinguish double-quoted from single-quoted StringTokens

### DIFF
--- a/tinycss2/ast.py
+++ b/tinycss2/ast.py
@@ -342,14 +342,15 @@ class StringToken(Node):
         The unescaped value, as a Unicode string, without the quotes.
 
     """
-    __slots__ = ['value', 'representation']
+    __slots__ = ['value', 'representation', 'is_double_quoted']
     type = 'string'
     repr_format = '<{self.__class__.__name__} {self.representation}>'
 
-    def __init__(self, line, column, value, representation):
+    def __init__(self, line, column, value, representation, is_double_quoted):
         Node.__init__(self, line, column)
         self.value = value
         self.representation = representation
+        self.is_double_quoted = is_double_quoted
 
     def _serialize_to(self, write):
         write(self.representation)

--- a/tinycss2/tokenizer.py
+++ b/tinycss2/tokenizer.py
@@ -166,7 +166,7 @@ def parse_component_value_list(css, skip_comments=False):
                 repr = '"{}"'.format(serialize_string_value(value))
                 if error is not None:
                     repr = repr[:-1]
-                tokens.append(StringToken(line, column, value, repr))
+                tokens.append(StringToken(line, column, value, repr, c=='"'))
             if error is not None:
                 tokens.append(ParseError(line, column, *error))
         elif css.startswith('/*', pos):  # Comment


### PR DESCRIPTION
Hello!
I use tinycss2 to parse a superset of css and distinguishing `"quoted:identifier"` from `'value'` will be very useful