### PR TITLE
perfs: optimize serialize_string_value

### DIFF
--- a/tinycss2/serializer.py
+++ b/tinycss2/serializer.py
@@ -76,11 +76,12 @@ _replacement_string_value = {
         "\r": r"\D ",
         "\f": r"\C ",
     }
-_re_string_value = re.compile("["+"".join(re.escape(e) for e in _replacement_string_value.keys()) + "]",
-                          re.MULTILINE )
-
+_re_string_value = "".join(re.escape(e) for e in _replacement_string_value.keys())
+_re_string_value = re.compile("["+ _re_string_value + "]", re.MULTILINE )
+def _serialize_string_value_match(match):
+    return _replacement_string_value[match.group(0)]
 def serialize_string_value(value):
-    return _re_string_value.sub(lambda match: _replacement_string_value[match.group(0)], value)
+    return _re_string_value.sub(_serialize_string_value_match, value)
 
 
 def serialize_url(value):

--- a/tinycss2/serializer.py
+++ b/tinycss2/serializer.py
@@ -79,27 +79,8 @@ _replacement_string_value = {
 _re_string_value = re.compile("["+"".join(re.escape(e) for e in _replacement_string_value.keys()) + "]",
                           re.MULTILINE )
 
-def fast_serialize_string_value(value):
-    return _re_string_value.sub(lambda match: _replacement_string_value[match.group(0)], value)
-
-
-def slow_serialize_string_value(value):
-    return ''.join(
-        r'\"' if c == '"' else
-        r'\\' if c == '\\' else
-        r'\A ' if c == '\n' else
-        r'\D ' if c == '\r' else
-        r'\C ' if c == '\f' else
-        c
-        for c in value
-    )
-
 def serialize_string_value(value):
-    assert isinstance(value, str),type(value)
-    ref = slow_serialize_string_value(value)
-    new = fast_serialize_string_value(value)
-    assert ref == new,(ref, new)
-    return new
+    return _re_string_value.sub(lambda match: _replacement_string_value[match.group(0)], value)
 
 
 def serialize_url(value):

--- a/tinycss2/serializer.py
+++ b/tinycss2/serializer.py
@@ -1,3 +1,6 @@
+import re
+
+
 def serialize(nodes):
     """Serialize nodes to CSS syntax.
 
@@ -66,7 +69,21 @@ def serialize_name(value):
     )
 
 
-def serialize_string_value(value):
+_replacement_string_value = {
+        '"': r"\"",
+        "\\": r"\\",
+        "\n": r"\A ",
+        "\r": r"\D ",
+        "\f": r"\C ",
+    }
+_re_string_value = re.compile("["+"".join(re.escape(e) for e in _replacement_string_value.keys()) + "]",
+                          re.MULTILINE )
+
+def fast_serialize_string_value(value):
+    return _re_string_value.sub(lambda match: _replacement_string_value[match.group(0)], value)
+
+
+def slow_serialize_string_value(value):
     return ''.join(
         r'\"' if c == '"' else
         r'\\' if c == '\\' else
@@ -76,6 +93,13 @@ def serialize_string_value(value):
         c
         for c in value
     )
+
+def serialize_string_value(value):
+    assert isinstance(value, str),type(value)
+    ref = slow_serialize_string_value(value)
+    new = fast_serialize_string_value(value)
+    assert ref == new,(ref, new)
+    return new
 
 
 def serialize_url(value):


### PR DESCRIPTION
I have found `serialize_string_value` to be a bottleneck in my code, and this was fixed by hotpatching and replacing it to use str.replace instead of "".join.

Benchmark:

```
def slow_serialize_string_value(value):
    return ''.join(
        r'\"' if c == '"' else
        r'\\' if c == '\\' else
        r'\A ' if c == '\n' else
        r'\D ' if c == '\r' else
        r'\C ' if c == '\f' else
        c
        for c in value
    )

_replacement_string_value = {
        '"': r"\"",
        "\\": r"\\",
        "\n": r"\A ",
        "\r": r"\D ",
        "\f": r"\C ",
    }
_re_string_value = "".join(re.escape(e) for e in _replacement_string_value.keys())
_re_string_value = re.compile("["+ _re_string_value + "]", re.MULTILINE )
def _serialize_string_value_match(match):
    return _replacement_string_value[match.group(0)]
def fast_serialize_string_value(value):
    return _re_string_value.sub(_serialize_string_value_match, value)

string = "".join(chr(random.randint(0, 255)) for _ in range(10_000_000))
small_string = "".join(chr(random.randint(0, 255)) for _ in range(1000))

%timeit fast_serialize_string_value(string)
# 75.7 ms ± 178 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit slow_serialize_string_value(string)
# 954 ms ± 5.04 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit slow_serialize_string_value(string)
# 97 μs ± 1.22 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

%timeit fast_serialize_string_value(small_string)
# 6.8 μs ± 50.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)