### PR TITLE
Fix tokenizer crash on escaped Dimension units and Function names

### DIFF
--- a/tests/test_tinycss2.py
+++ b/tests/test_tinycss2.py
@@ -477,3 +477,18 @@ def test_backslash_delim():
 def test_bad_unicode():
     parse_one_declaration('background:\udca9')
     parse_rule_list('@\udca9')
+
+def test_escape_in_dimension_token():
+    tokens = parse_component_value_list('0\\dddf')
+    assert len(tokens) == 1
+    dimension_token = tokens[0]
+    assert isinstance(dimension_token, DimensionToken)
+    assert dimension_token.int_value == 0
+    assert dimension_token.unit == '\udddf'
+
+def test_escape_in_function_name():
+    tokens = parse_component_value_list('\\dddf()')
+    assert len(tokens) == 1
+    function_block = tokens[0]
+    assert isinstance(function_block, FunctionBlock)
+    assert function_block.name == '\udddf'

--- a/tinycss2/ast.py
+++ b/tinycss2/ast.py
@@ -559,7 +559,10 @@ class DimensionToken(Node):
         self.is_integer = int_value is not None
         self.representation = representation
         self.unit = unit
-        self.lower_unit = ascii_lower(unit)
+        try:
+            self.lower_unit = ascii_lower(unit)
+        except UnicodeEncodeError:
+            self.lower_unit = unit
 
     def _serialize_to(self, write):
         write(self.representation)
@@ -693,7 +696,10 @@ class FunctionBlock(Node):
     def __init__(self, line, column, name, arguments):
         Node.__init__(self, line, column)
         self.name = name
-        self.lower_name = ascii_lower(name)
+        try:
+            self.lower_name = ascii_lower(name)
+        except UnicodeEncodeError:
+            self.lower_name = name
         self.arguments = arguments
 
     def _serialize_to(self, write):

--- a/tinycss2/tokenizer.py
+++ b/tinycss2/tokenizer.py
@@ -70,7 +70,11 @@ def parse_component_value_list(css, skip_comments=False):
                 tokens.append(IdentToken(line, column, value))
                 continue
             pos += 1  # Skip the '('
-            if ascii_lower(value) == 'url':
+            try:
+                is_url = ascii_lower(value) == 'url'
+            except UnicodeEncodeError:
+                is_url = value == 'url'
+            if is_url:
                 url_pos = pos
                 while css.startswith((' ', '\n', '\t'), url_pos):
                     url_pos += 1


### PR DESCRIPTION
This PR fixes a tokenizer crash when escape characters are used in `DimensionToken` units or function names.

`DimensionToken` previously assumed that unit was valid ASCII, but escapes in the unit caused a crash.
A similar issue exists in `FunctionBlock` when escapes are present in function names.
This bug was discovered by OSS-Fuzz: [issue 42520376](https://issues.oss-fuzz.com/issues/42520376?utm_source=chatgpt.com)

The PR adds guards to `DimensionToken` and `FunctionBlock`, consistent with the handling already in `IdentToken` and `AtKeywordToken`.
It also adds an extra guard in `parse_component_value_list`, which would otherwise lead to a crash.

The new tests, `test_escape_in_dimension_token` and `test_escape_in_function_name`, reproduced crashes before but now pass successfully.